### PR TITLE
Feature/last encounter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
 
     <div class="row">
         <div class="col-lg-10 main-div">
-            <form action="/" method="post">
+            <form id="joinChatForm" action="/" method="post">
                 <div class="form-group">
                     <label>Username</label>
                     <input type="text" name="usrnm" id="exampleFormControlInput1" spellcheck="false" autocomplete="off" required>
@@ -39,12 +39,13 @@
                         <option name="room" value="Artificial Intelligence">Artificial Intelligence</option>
                     </select>
                 </div>
-                <button type="submit">
+                <button id="joinChat" type="submit">
                     Join Chat!
                 </button>
             </form>
         </div>
     </div>
+<script src="./js/lastEncounter.js"></script>
 </body>
 
 </html>

--- a/public/js/lastEncounter.js
+++ b/public/js/lastEncounter.js
@@ -1,0 +1,15 @@
+const $username = document.querySelector('#exampleFormControlInput1');
+const $roomSelector = document.querySelector('#exampleFormControlSelect1');
+const $joinChatFrom = document.querySelector('#joinChatForm');
+
+const lastUsedUserName = localStorage.getItem('last_used_username');
+const lastJoinedRoom = localStorage.getItem('last_joined_room');
+if (lastUsedUserName !== null)
+    $username.value = lastUsedUserName;
+if (lastJoinedRoom !== null)
+    $roomSelector.value = lastJoinedRoom;
+
+$joinChatFrom.addEventListener('submit', () => {
+    localStorage.setItem('last_used_username', $username.value);
+    localStorage.setItem('last_joined_room', $roomSelector.value);
+});


### PR DESCRIPTION
Issue: 47


#### Short description of what this resolves:
Whenever a user first comes to the website his username and room preference will be stored in the local storage and whenever he revisits again it will be used on the page.


#### Changes proposed in this pull request and/or Screenshots of changes:

- Last username and Last joined room will be stored in local storage and used again when revisiting website
- If the username or room name is changed then it will get updated in the local storage
- https://www.loom.com/share/b288aa422a3749c796d6b5fcff18782d