### PR TITLE
Fixed it to show the name of the user when he enters the chat room

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,7 @@ io.on('connection', socket => {
     }
 
     socket.emit("message", formatMessages("GeekChat Bot", "Welcome to GeekChat!"));
-    socket.broadcast.emit("message", formatMessages("GeekChat Bot", `A User entered the chat!`));
+    socket.broadcast.emit("message", formatMessages("GeekChat Bot", `${usrnm} entered the chat!`));
 
     socket.on("disconnect", () => {
         let user = usersArr.find(ob => ob.session_id === socket.id);


### PR DESCRIPTION
Issue: 122

#### Short description of what this resolves:
It used to show that A User has entered the chat but now I changed it to show the name of the user.

Live link:  https://aracquine-geek-chat.herokuapp.com/
#### Changes proposed in this pull request and/or Screenshots of changes:
A screenshot of the website is provided below:
![daniel-aracquine](https://user-images.githubusercontent.com/75336745/136075980-8e015f03-cef3-4478-8962-b4c167e82ff0.png)

Screenshot of change I made in code is provided below: 

![daniel-aracquine_changesInCode](https://user-images.githubusercontent.com/75336745/136076144-043128c2-6ae6-4679-b494-d08f37873daa.png)

-
-
-